### PR TITLE
finetune hook position from vehicle settings CU-2adktvw

### DIFF
--- a/qgcimages.qrc
+++ b/qgcimages.qrc
@@ -123,6 +123,7 @@
         <file alias="MAVLinkInspector">src/AnalyzeView/MAVLinkInspector.svg</file>
         <file alias="Megaphone.svg">src/ui/toolbar/Images/Megaphone.svg</file>
         <file alias="MotorComponentIcon.svg">src/AutoPilotPlugins/Common/Images/MotorComponentIcon.svg</file>
+        <file alias="HookComponentIcon.svg">src/AutoPilotPlugins/Common/Images/HookComponentIcon.svg</file>
         <file alias="no-logging-light.svg">src/AutoPilotPlugins/PX4/Images/no-logging-light.svg</file>
         <file alias="no-logging.svg">src/AutoPilotPlugins/PX4/Images/no-logging.svg</file>
         <file alias="ObjectAvoidance.svg">src/AutoPilotPlugins/PX4/Images/ObjectAvoidance.svg</file>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1042,6 +1042,8 @@ HEADERS+= \
     src/AutoPilotPlugins/Common/ESP8266Component.h \
     src/AutoPilotPlugins/Common/ESP8266ComponentController.h \
     src/AutoPilotPlugins/Common/MotorComponent.h \
+    src/AutoPilotPlugins/Common/HookComponent.h \
+    src/AutoPilotPlugins/Common/HookComponentController.h \
     src/AutoPilotPlugins/Common/RadioComponentController.h \
     src/AutoPilotPlugins/Common/SyslinkComponent.h \
     src/AutoPilotPlugins/Common/SyslinkComponentController.h \
@@ -1064,6 +1066,8 @@ SOURCES += \
     src/AutoPilotPlugins/Common/ESP8266Component.cc \
     src/AutoPilotPlugins/Common/ESP8266ComponentController.cc \
     src/AutoPilotPlugins/Common/MotorComponent.cc \
+    src/AutoPilotPlugins/Common/HookComponent.cc \
+    src/AutoPilotPlugins/Common/HookComponentController.cc \
     src/AutoPilotPlugins/Common/RadioComponentController.cc \
     src/AutoPilotPlugins/Common/SyslinkComponent.cc \
     src/AutoPilotPlugins/Common/SyslinkComponentController.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -67,6 +67,7 @@
         <file alias="MockLink.qml">src/ui/preferences/MockLink.qml</file>
         <file alias="MockLinkSettings.qml">src/ui/preferences/MockLinkSettings.qml</file>
         <file alias="MotorComponent.qml">src/AutoPilotPlugins/Common/MotorComponent.qml</file>
+        <file alias="HookComponent.qml">src/AutoPilotPlugins/Common/HookComponent.qml</file>
         <file alias="OfflineMap.qml">src/QtLocationPlugin/QMLControl/OfflineMap.qml</file>
         <file alias="PlanToolBar.qml">src/PlanView/PlanToolBar.qml</file>
         <file alias="PlanToolBarIndicators.qml">src/PlanView/PlanToolBarIndicators.qml</file>

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(AutoPilotPlugins
 	Common/ESP8266Component.cc
 	Common/ESP8266ComponentController.cc
 	Common/MotorComponent.cc
+	Common/HookComponent.cc
+	Common/HookComponentController.cc
 	Common/RadioComponentController.cc
 	Common/SyslinkComponent.cc
 	Common/SyslinkComponentController.cc

--- a/src/AutoPilotPlugins/Common/CMakeLists.txt
+++ b/src/AutoPilotPlugins/Common/CMakeLists.txt
@@ -3,6 +3,7 @@ SOURCES
     ESP8266Component.qml
     ESP8266ComponentSummary.qml
     MotorComponent.qml
+    HookComponent.qml
     RadioComponent.qml
     SetupPage.qml
     SyslinkComponent.qml

--- a/src/AutoPilotPlugins/Common/HookComponent.cc
+++ b/src/AutoPilotPlugins/Common/HookComponent.cc
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "HookComponent.h"
+
+HookComponent::HookComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
+    VehicleComponent(vehicle, autopilot, parent),
+    _name(tr("Hook"))
+{
+
+}
+
+QString HookComponent::name(void) const
+{
+    return _name;
+}
+
+QString HookComponent::description(void) const
+{
+    return tr("Hook Setup is used to manually test the hook control and adjust the hook position.");
+}
+
+QString HookComponent::iconResource(void) const
+{
+    return QStringLiteral("/qmlimages/HookComponentIcon.svg");
+}
+
+bool HookComponent::requiresSetup(void) const
+{
+    return false;
+}
+
+bool HookComponent::setupComplete(void) const
+{
+    return true;
+}
+
+QStringList HookComponent::setupCompleteChangedTriggerList(void) const
+{
+    return QStringList();
+}
+
+QUrl HookComponent::setupSource(void) const
+{
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/HookComponent.qml"));
+}
+
+QUrl HookComponent::summaryQmlSource(void) const
+{
+    return QUrl();
+}

--- a/src/AutoPilotPlugins/Common/HookComponent.h
+++ b/src/AutoPilotPlugins/Common/HookComponent.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#ifndef HookComponent_H
+#define HookComponent_H
+
+#include "VehicleComponent.h"
+#include "Fact.h"
+
+class HookComponent : public VehicleComponent
+{
+    Q_OBJECT
+    
+public:
+    HookComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = nullptr);
+    
+    // Virtuals from VehicleComponent
+    QStringList setupCompleteChangedTriggerList(void) const final;
+    
+    // Virtuals from VehicleComponent
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    virtual QUrl setupSource(void) const;
+    QUrl summaryQmlSource(void) const final;
+
+private:
+    const QString   _name;
+};
+
+#endif

--- a/src/AutoPilotPlugins/Common/HookComponent.qml
+++ b/src/AutoPilotPlugins/Common/HookComponent.qml
@@ -37,7 +37,7 @@ SetupPage {
                 wrapMode:       Text.WordWrap
                 text:           qsTr("These controls can be used to move the hook and tune the closed position\n") +
                                 qsTr("\"Backwards\" and \"Forwards\" buttons move the hook. The number controls how far the hook moves with one button press\n") +
-                                qsTr("Once it is in the right position, use \"Set closed position\" to store this position as new closed position")
+                                qsTr("Once it is in the right position, use \"Set closed/open position\" to store this position as new closed/open position")
             }
 
             Row {
@@ -46,10 +46,6 @@ SetupPage {
                     text: "Backwards"
                     onClicked: {controller.hookStep(-parseInt(numSteps.text));}
                 }
-                // FactTextField {
-                //     fact: _flyViewSettings.landingStationSpeed
-                //     onEditingFinished: landingStationController.setSpeed(fact.value)
-                // }
                 QGCTextField {
                     id:                 numSteps
                     maximumLength:      5
@@ -61,11 +57,18 @@ SetupPage {
                     text: "Forwards"
                     onClicked: {controller.hookStep(parseInt(numSteps.text));}
                 }
+            }
+            Row {
+                spacing: ScreenTools.defaultFontPixelWidth
                 QGCButton {
                     text: "Set closed position"
-                    onClicked: {controller.hookReset()}
+                    onClicked: {controller.hookReset(0)}
                 }
-            } // Row
+                QGCButton {
+                    text: "Set open position"
+                    onClicked: {controller.hookReset(1)}
+                }
+            }
         } // Column
     } // Component
 } // SetupPage

--- a/src/AutoPilotPlugins/Common/HookComponent.qml
+++ b/src/AutoPilotPlugins/Common/HookComponent.qml
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+SetupPage {
+    id:             hookPage
+    pageComponent:  pageComponent
+
+    HookComponentController {
+        id:             controller
+    }
+
+    Component {
+        id: pageComponent
+
+        Column {
+            spacing: ScreenTools.defaultFontPixelHeight
+
+            QGCLabel {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                wrapMode:       Text.WordWrap
+                text:           qsTr("These controls can be used to move the hook and tune the closed position\n") +
+                                qsTr("\"Backwards\" and \"Forwards\" buttons move the hook. The number controls how far the hook moves with one button press\n") +
+                                qsTr("Once it is in the right position, use \"Set closed position\" to store this position as new closed position")
+            }
+
+            Row {
+                spacing: ScreenTools.defaultFontPixelWidth
+                QGCButton {
+                    text: "Backwards"
+                    onClicked: {controller.hookStep(-parseInt(numSteps.text));}
+                }
+                // FactTextField {
+                //     fact: _flyViewSettings.landingStationSpeed
+                //     onEditingFinished: landingStationController.setSpeed(fact.value)
+                // }
+                QGCTextField {
+                    id:                 numSteps
+                    maximumLength:      5
+                    inputMethodHints:   Qt.ImhDigitsOnly
+                    validator:          IntValidator {bottom: -9999; top: 9999;}
+                    text:               qsTr("100")
+                }
+                QGCButton {
+                    text: "Forwards"
+                    onClicked: {controller.hookStep(parseInt(numSteps.text));}
+                }
+                QGCButton {
+                    text: "Set closed position"
+                    onClicked: {controller.hookReset()}
+                }
+            } // Row
+        } // Column
+    } // Component
+} // SetupPage

--- a/src/AutoPilotPlugins/Common/HookComponentController.cc
+++ b/src/AutoPilotPlugins/Common/HookComponentController.cc
@@ -20,9 +20,9 @@ HookComponentController::hookStep(int num_steps)
 }
 
 void
-HookComponentController::hookReset()
+HookComponentController::hookReset(int position)
 {
-    _sendHookResetCommand();
+    _sendHookResetCommand(position);
 }
 
 void
@@ -37,9 +37,9 @@ HookComponentController::_sendHookStepCommand(int num_steps)
     _sendNamedValueFloat("hook_stp", num_steps);
 }
 void
-HookComponentController::_sendHookResetCommand()
+HookComponentController::_sendHookResetCommand(int position)
 {
-    _sendNamedValueFloat("hook_rst", 0.0f);
+    _sendNamedValueFloat("hook_rst", position);
 }
 
 void

--- a/src/AutoPilotPlugins/Common/HookComponentController.cc
+++ b/src/AutoPilotPlugins/Common/HookComponentController.cc
@@ -1,0 +1,71 @@
+#include "HookComponentController.h"
+#include "MultiVehicleManager.h"
+#include <iostream>
+
+QGC_LOGGING_CATEGORY(HookComponent, "HookComponent")
+
+HookComponentController::HookComponentController() : _vehicle(nullptr) 
+{
+    _since_start_timer.start(); // start the boot timer to timestamp the mavlink messages
+
+    MultiVehicleManager *manager = qgcApp()->toolbox()->multiVehicleManager();
+    connect(manager, &MultiVehicleManager::activeVehicleChanged, this, &HookComponentController::_setActiveVehicle);
+    this->_setActiveVehicle(manager->activeVehicle());
+}
+
+void
+HookComponentController::hookStep(int num_steps)
+{
+    _sendHookStepCommand(num_steps);
+}
+
+void
+HookComponentController::hookReset()
+{
+    _sendHookResetCommand();
+}
+
+void
+HookComponentController::_setActiveVehicle(Vehicle* vehicle)
+{
+    _vehicle = vehicle;
+}
+
+void
+HookComponentController::_sendHookStepCommand(int num_steps)
+{
+    _sendNamedValueFloat("hook_stp", num_steps);
+}
+void
+HookComponentController::_sendHookResetCommand()
+{
+    _sendNamedValueFloat("hook_rst", 0.0f);
+}
+
+void
+HookComponentController::_sendNamedValueFloat(const char* name, float value)
+{
+    if (_vehicle) {
+        std::cout << "sending named value float with name " << name << " and value " << value << std::endl;
+        WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+        if (!weakLink.expired()) {
+            SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+            qCDebug(HookComponent) << "Sending NAMED_VALUE_FLOAT with name " << name << " and value " << value;
+            mavlink_message_t msg;
+            mavlink_msg_named_value_float_pack_chan(
+                        qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
+                        qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
+                        sharedLink->mavlinkChannel(),
+                        &msg,
+                        this->_since_start_timer.elapsed(),
+                        name,
+                        value);
+            _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        }
+    }
+    else
+    {
+        std::cout << "not sending named value float since no vehicle connected" << std::endl;
+    }
+}

--- a/src/AutoPilotPlugins/Common/HookComponentController.h
+++ b/src/AutoPilotPlugins/Common/HookComponentController.h
@@ -13,14 +13,14 @@ class HookComponentController : public QObject
 public:
     HookComponentController();
     Q_INVOKABLE void hookStep(int num_steps);
-    Q_INVOKABLE void hookReset();
+    Q_INVOKABLE void hookReset(int positioin);
 
 private:
     Vehicle* _vehicle;
     QElapsedTimer _since_start_timer;
     void _setActiveVehicle(Vehicle* vehicle);
     void _sendHookStepCommand(int num_steps);
-    void _sendHookResetCommand();
+    void _sendHookResetCommand(int position);
     void _sendNamedValueFloat(const char* name, float value);
 };
 

--- a/src/AutoPilotPlugins/Common/HookComponentController.h
+++ b/src/AutoPilotPlugins/Common/HookComponentController.h
@@ -1,0 +1,27 @@
+#ifndef HookComponentController_H
+#define HookComponentController_H
+
+#include "QGCApplication.h"
+#include <QElapsedTimer>
+
+Q_DECLARE_LOGGING_CATEGORY(HookComponent)
+
+class HookComponentController : public QObject
+{
+    Q_OBJECT
+
+public:
+    HookComponentController();
+    Q_INVOKABLE void hookStep(int num_steps);
+    Q_INVOKABLE void hookReset();
+
+private:
+    Vehicle* _vehicle;
+    QElapsedTimer _since_start_timer;
+    void _setActiveVehicle(Vehicle* vehicle);
+    void _sendHookStepCommand(int num_steps);
+    void _sendHookResetCommand();
+    void _sendNamedValueFloat(const char* name, float value);
+};
+
+#endif

--- a/src/AutoPilotPlugins/Common/Images/HookComponentIcon.svg
+++ b/src/AutoPilotPlugins/Common/Images/HookComponentIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-layer-backward" viewBox="0 0 16 16">
+  <path d="M8.354 15.854a.5.5 0 0 1-.708 0l-3-3a.5.5 0 0 1 0-.708l1-1a.5.5 0 0 1 .708 0l.646.647V4H1a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H9v7.793l.646-.647a.5.5 0 0 1 .708 0l1 1a.5.5 0 0 1 0 .708l-3 3z"/>
+  <path d="M1 9a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4.5a.5.5 0 0 1 0 1H1v2h4.5a.5.5 0 0 1 0 1H1zm9.5 0a.5.5 0 0 1 0-1H15V6h-4.5a.5.5 0 0 1 0-1H15a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-4.5z"/>
+</svg>

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -89,6 +89,10 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_motorComponent)));
 
+                _hookComponent = new HookComponent(_vehicle, this, this);
+                _hookComponent->setupTriggerSignals();
+                _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_hookComponent)));
+
                 _safetyComponent = new SafetyComponent(_vehicle, this, this);
                 _safetyComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_safetyComponent)));

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -22,6 +22,7 @@
 #include "CameraComponent.h"
 #include "PowerComponent.h"
 #include "MotorComponent.h"
+#include "HookComponent.h"
 #include "PX4TuningComponent.h"
 #include "PX4FlightBehavior.h"
 #include "SyslinkComponent.h"
@@ -58,6 +59,7 @@ protected:
     CameraComponent*        _cameraComponent;
     PowerComponent*         _powerComponent;
     MotorComponent*         _motorComponent;
+    HookComponent*          _hookComponent;
     PX4TuningComponent*     _tuningComponent;
     PX4FlightBehavior*      _flightBehavior;
     SyslinkComponent*       _syslinkComponent;

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -105,6 +105,7 @@
 #include "RosSSHThread.h"
 #include "RosSSHController.h"
 #include "LandingStationControlButtonsController.h"
+#include "HookComponentController.h"
 
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
@@ -519,6 +520,7 @@ void QGCApplication::_initCommon()
     qmlRegisterType<RosSSHThread>                   (kQGCControllers,                          1, 0, "RosSSHThread");
     qmlRegisterType<RosSSHController>               (kQGCControllers,                          1, 0, "RosSSHController");
     qmlRegisterType<LandingStationControlButtonsController>(kQGCControllers,                   1, 0, "LandingStationControlButtonsController");
+    qmlRegisterType<HookComponentController>        (kQGCControllers,                       1, 0, "HookComponentController");
 
 
     qmlRegisterType<TerrainProfile>                 ("QGroundControl.Controls",             1, 0, "TerrainProfile");


### PR DESCRIPTION
## Needs [auto-landing-detection PR#126](https://github.com/PackageGlider/auto-landing-detection/pull/126) to work ##
The current hook we use doesn't have an endstop so all the hook position control is relative. To correct the drift in the position from time to time we need buttons to manually move the hook and reset the new position as "closed" position of the hook. This PR adds a page to the Vehicle Setup which provides buttons to move the hook forward, move the hook backward and set the closed position as well as a text field to specify by how many steps the hook motor should move:

![image](https://user-images.githubusercontent.com/89455753/169557261-9a5f3646-2231-4562-9404-a43bf371b9d8.png)
