### PR TITLE
replace hooked button with leveling button CU-2ar6r0d

### DIFF
--- a/src/FlightDisplay/LandingStationControlButtons.qml
+++ b/src/FlightDisplay/LandingStationControlButtons.qml
@@ -63,9 +63,9 @@ Rectangle {
         }
         QGCButton {
             Layout.alignment: Qt.AlignHCenter
-            text: "Hook Hooked"
+            text: "Level"
             Layout.preferredWidth: _buttonWidth
-            onClicked: landingStationController.hookHooked()
+            onClicked: landingStationController.beltLevel()
         }
 
         QGCButton {

--- a/src/FlightDisplay/LandingStationControlButtons.qml
+++ b/src/FlightDisplay/LandingStationControlButtons.qml
@@ -61,11 +61,9 @@ Rectangle {
             fact: _flyViewSettings.landingStationSpeed
             onEditingFinished: landingStationController.setSpeed(fact.value)
         }
-        QGCButton {
-            Layout.alignment: Qt.AlignHCenter
-            text: "Level"
+        Item {
+            Layout.fillWidth: true
             Layout.preferredWidth: _buttonWidth
-            onClicked: landingStationController.beltLevel()
         }
 
         QGCButton {
@@ -106,9 +104,11 @@ Rectangle {
             onClicked: landingStationController.beltRotateRight()
         }
 
-        Item {
-            Layout.fillWidth: true
+        QGCButton {
+            Layout.alignment: Qt.AlignHCenter
+            text: "Hook Secure"
             Layout.preferredWidth: _buttonWidth
+            onClicked: landingStationController.hookSecured()
         }
         QGCButton {
             Layout.alignment: Qt.AlignHCenter
@@ -116,9 +116,11 @@ Rectangle {
             Layout.preferredWidth: _buttonWidth
             onClicked: landingStationController.beltDown()
         }
-        Item {
-            Layout.fillWidth: true
+        QGCButton {
+            Layout.alignment: Qt.AlignHCenter
+            text: "Level"
             Layout.preferredWidth: _buttonWidth
+            onClicked: landingStationController.beltLevel()
         }
 
         QGCLabel {

--- a/src/QmlControls/LandingStationControlButtonsController.cc
+++ b/src/QmlControls/LandingStationControlButtonsController.cc
@@ -80,6 +80,11 @@ LandingStationControlButtonsController::beltRotateRight(void)
 {
     _sendBeltCommand(1);
 }
+void
+LandingStationControlButtonsController::beltLevel(void)
+{
+    _sendBeltLevelCommand();
+}
 
 
 void
@@ -114,6 +119,11 @@ void
 LandingStationControlButtonsController::_sendBeltCommand(int value)
 {
     _sendNamedValueFloat("lan_act", value);
+}
+void
+LandingStationControlButtonsController::_sendBeltLevelCommand()
+{
+    _sendNamedValueFloat("lan_lvl", 0.0f);
 }
 
 void

--- a/src/QmlControls/LandingStationControlButtonsController.cc
+++ b/src/QmlControls/LandingStationControlButtonsController.cc
@@ -50,7 +50,7 @@ LandingStationControlButtonsController::hookClose(void)
     _sendHookCommand(0);
 }
 void
-LandingStationControlButtonsController::hookHooked(void)
+LandingStationControlButtonsController::hookSecured(void)
 {
     _sendHookCommand(2);
 }

--- a/src/QmlControls/LandingStationControlButtonsController.h
+++ b/src/QmlControls/LandingStationControlButtonsController.h
@@ -25,6 +25,7 @@ public:
     Q_INVOKABLE void beltDown();
     Q_INVOKABLE void beltRotateLeft();
     Q_INVOKABLE void beltRotateRight();
+    Q_INVOKABLE void beltLevel();
 
     Q_PROPERTY(int timeout READ getTimeout WRITE setTimeout NOTIFY timeoutChanged);
     Q_PROPERTY(int speed READ getSpeed WRITE setSpeed NOTIFY speedChanged);
@@ -44,6 +45,7 @@ private:
     void _sendHookCommand(int value);
     void _sendDeliveryCommand(int value);
     void _sendBeltCommand(int value);
+    void _sendBeltLevelCommand();
     void _sendNamedValueFloat(const char* name, float value);
 };
 

--- a/src/QmlControls/LandingStationControlButtonsController.h
+++ b/src/QmlControls/LandingStationControlButtonsController.h
@@ -19,7 +19,7 @@ public:
     Q_INVOKABLE void setSpeed(int speed);
     Q_INVOKABLE void hookClose();
     Q_INVOKABLE void hookOpen();
-    Q_INVOKABLE void hookHooked();
+    Q_INVOKABLE void hookSecured();
     Q_INVOKABLE void beltStop();
     Q_INVOKABLE void beltUp();
     Q_INVOKABLE void beltDown();


### PR DESCRIPTION
Replaces hook hooked button with Level button which triggers a manual leveling of the glider on the landing station. This PR needs [PR #134](https://github.com/PackageGlider/auto-landing-detection/pull/134) on the ROS side